### PR TITLE
[feat]: 목표 기반 ETF 추천 페이지 구현

### DIFF
--- a/src/app/goal/page.tsx
+++ b/src/app/goal/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useGoalPlanner } from "@/hooks/useGoalPlanner";
+import { GoalPlannerForm } from "@/components/goal/GoalPlannerForm";
+import { GoalPlannerResults } from "@/components/goal/GoalPlannerResults";
+import { Loader2 } from "lucide-react";
+
+export default function GoalPlannerpage() {
+  const planner = useGoalPlanner();
+
+  return (
+    <main className="flex flex-col items-center gap-8 py-10 px-4">
+      <div className="text-center">
+        <h1 className="text-3xl font-bold">목표 설계</h1>
+        <p className="text-gray-500 mt-2">
+          과거 데이터 기반으로 목표 달성 확률이 높은 ETF를 찾아보세요.
+        </p>
+      </div>
+
+      <GoalPlannerForm planner={planner} />
+
+      {planner.isLoading && (
+        <div className="flex items-center gap-2">
+          <Loader2 className="h-6 w-6 animate-spin" />
+          <span>데이터를 분석하고 있습니다...</span>
+        </div>
+      )}
+
+      {planner.error && <p className="text-red-500">{planner.error}</p>}
+
+      {planner.results && <GoalPlannerResults results={planner.results} />}
+    </main>
+  );
+}

--- a/src/components/goal/EtfCandidateCard.tsx
+++ b/src/components/goal/EtfCandidateCard.tsx
@@ -1,0 +1,43 @@
+import { EtfCandidate } from "@/types/goal";
+import { Progress } from "@/components/ui/progress";
+
+const getHitRateColor = (rate: number) => {
+  if (rate >= 0.7) return "[&>div]:bg-green-500";
+  if (rate >= 0.4) return "[&>div]:bg-yellow-500";
+  return "[&>div]:bg-red-500";
+};
+
+export const EtfCandidateCard = ({ etf }: { etf: EtfCandidate }) => {
+  return (
+    <div className="rounded-lg border p-4 space-y-2">
+      <div className="flex justify-between items-center">
+        <p className="text-lg font-bold">
+          {etf.name}{" "}
+          <span className="text-sm font-normal text-gray-500">{etf.code}</span>
+        </p>
+        <span
+          className={`px-2 py-1 text-xs rounded-full ${
+            etf.riskMatch > 0.7 ? "bg-blue-100 text-blue-800" : "bg-gray-100"
+          }`}
+        >
+          궁합 {Math.round(etf.riskMatch * 100)}점
+        </span>
+      </div>
+      <div>
+        <label className="text-sm">
+          히트율: {Math.round(etf.hitRate * 100)}%
+        </label>
+        <Progress
+          value={etf.hitRate * 100}
+          className={getHitRateColor(etf.hitRate)}
+        />
+      </div>
+      <div className="text-sm text-gray-600 grid grid-cols-2 gap-1">
+        <p>예상 중앙값: {(etf.medianEndingValue / 10000).toFixed(0)}만원</p>
+        <p>중앙 CAGR: {(etf.medianCagr * 100).toFixed(1)}%</p>
+        <p>중앙 MDD: {(etf.medianMdd * 100).toFixed(1)}%</p>
+        <p>총 보수: {etf.expenseRatio * 100}%</p>
+      </div>
+    </div>
+  );
+};

--- a/src/components/goal/GoalPlannerForm.tsx
+++ b/src/components/goal/GoalPlannerForm.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+import { useGoalPlanner } from "@/hooks/useGoalPlanner";
+
+type GoalPlannerFormProps = {
+  planner: ReturnType<typeof useGoalPlanner>;
+};
+
+export const GoalPlannerForm = ({ planner }: GoalPlannerFormProps) => {
+  const { input, setInput, handleSubmit, isLoading } = planner;
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInput((prev) => ({ ...prev, [e.target.name]: +e.target.value }));
+  };
+
+  return (
+    <Card className="w-full max-w-2xl">
+      <form onSubmit={planner.handleSubmit}>
+        <CardHeader>
+          <CardTitle className="text-lg">투자 목표 입력</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="space-y-2">
+            <Label htmlFor="targetAmount">목표 금액 (₩)</Label>
+            <Input
+              id="targetAmount"
+              name="targetAmount"
+              type="number"
+              value={input.targetAmount}
+              onChange={handleInputChange}
+              min={10000}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="targetYears">목표 기간 (년)</Label>
+            <Input
+              id="targetYears"
+              name="targetYears"
+              type="number"
+              value={input.targetYears}
+              onChange={handleInputChange}
+              min={1}
+              max={40}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="initialAmount">초기 투자금 (₩)</Label>
+            <Input
+              id="initialAmount"
+              name="initialAmount"
+              type="number"
+              value={input.initialAmount}
+              onChange={handleInputChange}
+              min={0}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="monthlyContribution">월 적립액 (₩)</Label>
+            <Input
+              id="monthlyContribution"
+              name="monthlyContribution"
+              type="number"
+              value={input.monthlyContribution}
+              onChange={handleInputChange}
+              min={0}
+            />
+          </div>
+          <div className="col-span-full space-y-2">
+            <Label>위험 성향 (안정 0 ↔ 100 공격)</Label>
+            <Slider
+              min={0}
+              max={100}
+              step={1}
+              value={[input.riskProfile ?? 50]}
+              onValueChange={(v) =>
+                setInput((prev) => ({ ...prev, riskProfile: v[0] }))
+              }
+            />
+            <span className="text-sm text-muted-foreground">
+              {input.riskProfile ?? 50}
+            </span>
+          </div>
+        </CardContent>
+        <CardFooter className="flex justify-end gap-4">
+          <Button
+            type="submit"
+            disabled={isLoading}
+            className="w-full md:w-auto"
+          >
+            {isLoading ? "분석 중..." : "시뮬레이션"}
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+};

--- a/src/components/goal/GoalPlannerResults.tsx
+++ b/src/components/goal/GoalPlannerResults.tsx
@@ -1,0 +1,28 @@
+import { GoalPlannerResponse } from "@/types/goal";
+import { EtfCandidateCard } from "./EtfCandidateCard";
+
+export const GoalPlannerResults = ({
+  results,
+}: {
+  results: GoalPlannerResponse;
+}) => {
+  return (
+    <div className="w-full max-w-2xl space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold">분석 결과</h2>
+        <p>
+          필요 CAGR:{" "}
+          <span className="font-bold text-blue-600">
+            {(results.neededCAGR * 100).toFixed(2)}%
+          </span>
+        </p>
+      </div>
+      <div className="space-y-4">
+        <h3 className="text-xl font-semibold">Top ETF 추천 리스트</h3>
+        {results.etfCandidates.map((etf) => (
+          <EtfCandidateCard key={etf.code} etf={etf} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,57 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+
+import { cn } from "@/lib/utils"
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex w-full touch-none select-none items-center",
+      className
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+))
+Slider.displayName = SliderPrimitive.Root.displayName
+
+export { Slider }

--- a/src/hooks/useGoalPlanner.ts
+++ b/src/hooks/useGoalPlanner.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { GoalPlannerRequest, GoalPlannerResponse } from "@/types/goal";
+
+export const useGoalPlanner = () => {
+  // 1. 사용자 입력 상태 관리 (명세 3.1)
+  const [input, setInput] = useState<GoalPlannerRequest>({
+    targetAmount: 100_000_000,
+    targetYears: 10,
+    initialAmount: 0,
+    monthlyContribution: 300_000,
+    riskProfile: 50,
+  });
+
+  // 2. API 연동 관련 상태 관리
+  const [results, setResults] = useState<GoalPlannerResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 3. 필요 CAGR 프리뷰 계산 (명세 5.1)
+  const neededCagr = useMemo(() => {
+    // 이전과 동일한 CAGR 계산 로직
+    const P = input.initialAmount;
+    const A = input.monthlyContribution * 12;
+    const FV = input.targetAmount;
+    const n = input.targetYears;
+    if (FV <= 0 || n <= 0) return 0;
+    let r = 0.07;
+    for (let i = 0; i < 10; i++) {
+      const fvGuess = P * (1 + r) ** n + (A / r) * ((1 + r) ** n - 1);
+      const derivative =
+        P * n * (1 + r) ** (n - 1) +
+        (A / r ** 2) * (n * r * (1 + r) ** (n - 1) - ((1 + r) ** n - 1));
+      const nextR = r - (fvGuess - FV) / derivative;
+      if (isNaN(nextR) || !isFinite(nextR)) break;
+      r = nextR;
+    }
+    return Math.max(r * 100, 0);
+  }, [input]);
+
+  // 4. API 호출 핸들러
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError(null);
+    setResults(null);
+
+    try {
+      // 명세 3.1: API 호출
+      const response = await fetch("/api/v1/goal-planner", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+
+      if (!response.ok) {
+        throw new Error("서버에서 오류가 발생했습니다.");
+      }
+
+      const data: GoalPlannerResponse = await response.json();
+      setResults(data);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다."
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    input,
+    setInput,
+    results,
+    isLoading,
+    error,
+    neededCagr,
+    handleSubmit,
+  };
+};

--- a/src/types/goal.ts
+++ b/src/types/goal.ts
@@ -1,0 +1,29 @@
+export interface GoalPlannerRequest {
+  targetAmount: number;
+  targetYears: number;
+  initialAmount: number;
+  monthlyContribution: number;
+  riskProfile?: number;
+}
+
+export interface EtfCandidate {
+  code: string;
+  name: string;
+  hitRate: number;
+  riskMatch: number;
+  goalScore: number;
+  medianEndingValue: number;
+  medianCagr: number;
+  medianMdd: number;
+  expenseRatio: number;
+}
+
+export interface GoalPlannerResponse {
+  inputEcho: GoalPlannerRequest;
+  neededCAGR: number;
+  etfCandidates: EtfCandidate[];
+  nearMiss: any[];
+  meta: {
+    calcVersion: string;
+  };
+}


### PR DESCRIPTION
## #️⃣ Issue Number

#20 

## 📝 요약(Summary)

목표 설계 기능 명세서에 따라, 사용자가 투자 목표를 입력하고 추천 ETF를 받을 수 있는 '목표 기반 ETF 추천' 페이지의 프론트엔드 UI와 기본 로직을 구현했습니다.

상태 및 계산 로직을 관리하는 useGoalPlanner 커스텀 훅을 구현했습니다.

사용자 입력을 받는 GoalPlannerForm과 결과 목록을 보여주는 GoalPlannerResults 등 UI 컴포넌트를 기능 단위로 분리했습니다.

API 연동을 위한 로딩, 에러, 결과 표시 상태 분기 처리를 완료했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

<img width="819" height="609" alt="image" src="https://github.com/user-attachments/assets/5eec08f7-dd5c-4ffa-95d9-8aaf79d0381b" />

## 💬 공유사항 to 리뷰어

기능 명세서에 따라 로직과 UI를 분리하는 데 집중했습니다. useGoalPlanner 훅에 상태 관리 및 API 호출 로직이 모여있으니 이 부분을 중점적으로 봐주시면 좋을 것 같습니다.

현재 백엔드 API (/api/v1/goal-planner)는 아직 연동되지 않은 상태이며, handleSubmit 함수 내에서 호출하도록 준비만 되어 있습니다.

shadcn/ui를 기반으로 UI 컴포넌트를 구성했습니다.

상세한 레이아웃은 수정이 추후에 수정 예정이지만 반영해줬으면 하는 사항이 있다면 편하게 말씀해주세요
