### PR TITLE
메인 화면에서 find로 넘어갈 때 검색어 포함해서 넘어가기+URL 더럽지 않게

### DIFF
--- a/src/app/(pages)/find/page.tsx
+++ b/src/app/(pages)/find/page.tsx
@@ -8,7 +8,7 @@ import {
   toggleFavorite as toggleFavoriteAPI,
   fetchFavoriteEtfCodes,
 } from "@/services/etfFavoriteService";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import FilterTabs from "@/components/blocks/ETFFind/FilterTabs";
 import FilterButtons from "@/components/blocks/ETFFind/FilterButtons";
@@ -18,10 +18,14 @@ import HoldingTable from "@/components/blocks/ETFFind/HoldingTable";
 import CompareModal from "@/components/blocks/ETFCompare/ETFComapreModal";
 
 export default function FindPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const initialQuery = searchParams.get("query") ?? "";
+
   const [selectedTab, setSelectedTab] = useState("유형별");
   const [selectedType, setSelectedType] = useState("전체");
   const [selectedTheme, setSelectedTheme] = useState("전체");
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState(initialQuery);
 
   const [etfData, setEtfData] = useState<ETFView[]>([]);
   const [holdingsData, setHoldingsData] = useState<HoldingView[]>([]);
@@ -32,7 +36,8 @@ export default function FindPage() {
   const [modalVisible, setModalVisible] = useState(false);
   const [modalData, setModalData] = useState<any[]>([]);
   const [showPlaceholder, setShowPlaceholder] = useState(true);
-  const router = useRouter();
+  const [hasInitialized, setHasInitialized] = useState(false);
+
   const tabList = ["유형별", "테마별", "관심별"];
   const assetFilters = [
     "전체",
@@ -117,9 +122,134 @@ export default function FindPage() {
     }
   };
 
+  // 검색 실행 함수 (URL 파라미터용)
+  const executeSearchWithQuery = async (query: string) => {
+    setIsLoading(true);
+
+    const params: any = {
+      query: query,
+      sort: viewMode === "ETF로 보기" ? "etf_code" : "weight_pct",
+    };
+
+    if (selectedTab === "관심별") {
+      params.isFavorite = true;
+    } else {
+      if (selectedType !== "전체") params.assetClass = selectedType;
+      if (selectedTheme !== "전체") params.theme = selectedTheme;
+    }
+
+    try {
+      if (viewMode === "ETF로 보기") {
+        const data: any[] = await fetchEtfData(params);
+        const formatted = (data as any[]).map((etf) => ({
+          name: etf.etf_name,
+          etfCode: etf.etf_code,
+          nav: etf.latest_price,
+          week1: etf.week1 ?? "-",
+          month1: etf.month1 ?? "-",
+          month3: etf.month3 ?? "-",
+          month6: etf.month6 ?? "-",
+          year1: etf.year1 ?? "-",
+          year3: etf.year3 ?? "-",
+          inception: etf.inception ?? "-",
+        }));
+        setEtfData(formatted);
+
+        // 관심 ETF 세팅
+        try {
+          const favoriteCodes = await fetchFavoriteEtfCodes();
+          setFavoriteEtfCodes(favoriteCodes);
+        } catch (err: any) {
+          console.warn(
+            "💥 관심 ETF 목록 가져오기 실패 (비로그인일 수 있음)",
+            err
+          );
+        }
+      } else {
+        const data: any[] = await fetchHoldingsData(params);
+        const formatted = (data as any[]).map((holding) => ({
+          etfName: holding.etf_name,
+          etfCode: holding.etf_code,
+          holdingName: holding.holding_name,
+          weight: holding.weight_pct,
+        }));
+        setHoldingsData(formatted);
+      }
+    } catch (err) {
+      console.error("데이터 불러오기 실패:", err);
+      if (viewMode === "ETF로 보기") setEtfData([]);
+      else setHoldingsData([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 검색 실행 함수
+  const executeSearch = async () => {
+    setIsLoading(true);
+
+    const params: any = {
+      query: searchQuery,
+      sort: viewMode === "ETF로 보기" ? "etf_code" : "weight_pct",
+    };
+
+    if (selectedTab === "관심별") {
+      params.isFavorite = true;
+    } else {
+      if (selectedType !== "전체") params.assetClass = selectedType;
+      if (selectedTheme !== "전체") params.theme = selectedTheme;
+    }
+
+    try {
+      if (viewMode === "ETF로 보기") {
+        const data: any[] = await fetchEtfData(params);
+        const formatted = (data as any[]).map((etf) => ({
+          name: etf.etf_name,
+          etfCode: etf.etf_code,
+          nav: etf.latest_price,
+          week1: etf.week1 ?? "-",
+          month1: etf.month1 ?? "-",
+          month3: etf.month3 ?? "-",
+          month6: etf.month6 ?? "-",
+          year1: etf.year1 ?? "-",
+          year3: etf.year3 ?? "-",
+          inception: etf.inception ?? "-",
+        }));
+        setEtfData(formatted);
+
+        // 관심 ETF 세팅
+        try {
+          const favoriteCodes = await fetchFavoriteEtfCodes();
+          setFavoriteEtfCodes(favoriteCodes);
+        } catch (err: any) {
+          console.warn(
+            "💥 관심 ETF 목록 가져오기 실패 (비로그인일 수 있음)",
+            err
+          );
+        }
+      } else {
+        const data: any[] = await fetchHoldingsData(params);
+        const formatted = (data as any[]).map((holding) => ({
+          etfName: holding.etf_name,
+          etfCode: holding.etf_code,
+          holdingName: holding.holding_name,
+          weight: holding.weight_pct,
+        }));
+        setHoldingsData(formatted);
+      }
+    } catch (err) {
+      console.error("데이터 불러오기 실패:", err);
+      if (viewMode === "ETF로 보기") setEtfData([]);
+      else setHoldingsData([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const handleSearch = () => {
     if (searchQuery.trim()) {
-      router.push(`/find?query=${encodeURIComponent(searchQuery)}`);
+      // 현재 페이지에서 검색할 때는 URL을 업데이트하지 않고 바로 검색 실행
+      executeSearch();
     }
   };
 
@@ -139,71 +269,38 @@ export default function FindPage() {
     }
   };
 
-  // 🔥 API 요청 트리거
+  // URL 파라미터에서 검색어 가져오기 및 초기 검색 실행
   useEffect(() => {
-    const fetchData = async () => {
-      setIsLoading(true);
+    if (hasInitialized) return; // 이미 초기화된 경우 중복 실행 방지
 
-      const params: any = {
-        query: searchQuery,
-        sort: viewMode === "ETF로 보기" ? "etf_code" : "weight_pct",
-      };
+    const query = searchParams.get("query");
+    if (query) {
+      setSearchQuery(query);
+      setShowPlaceholder(false);
 
-      if (selectedTab === "관심별") {
-        params.isFavorite = true;
-      } else {
-        if (selectedType !== "전체") params.assetClass = selectedType;
-        if (selectedTheme !== "전체") params.theme = selectedTheme;
-      }
+      // URL 파라미터에서 검색어가 있으면 자동으로 검색 실행
+      setTimeout(() => {
+        executeSearchWithQuery(query);
 
-      try {
-        if (viewMode === "ETF로 보기") {
-          const data: any[] = await fetchEtfData(params);
-          const formatted = (data as any[]).map((etf) => ({
-            name: etf.etf_name,
-            etfCode: etf.etf_code,
-            nav: etf.latest_price,
-            week1: etf.week1 ?? "-",
-            month1: etf.month1 ?? "-",
-            month3: etf.month3 ?? "-",
-            month6: etf.month6 ?? "-",
-            year1: etf.year1 ?? "-",
-            year3: etf.year3 ?? "-",
-            inception: etf.inception ?? "-",
-          }));
-          setEtfData(formatted);
+        const newUrl = window.location.pathname;
+        window.history.replaceState({}, "", newUrl);
+      }, 100); // 약간의 지연을 주어 searchQuery가 설정된 후 실행
+    } else {
+      // 검색어가 없으면 모든 ETF 목록을 가져오기
+      setTimeout(() => {
+        executeSearchWithQuery("");
+      }, 100);
+    }
+    setHasInitialized(true);
+  }, [searchParams]);
 
-          // 관심 ETF 세팅
-          try {
-            const favoriteCodes = await fetchFavoriteEtfCodes();
-            setFavoriteEtfCodes(favoriteCodes);
-          } catch (err: any) {
-            console.warn(
-              "💥 관심 ETF 목록 가져오기 실패 (비로그인일 수 있음)",
-              err
-            );
-          }
-        } else {
-          const data: any[] = await fetchHoldingsData(params);
-          const formatted = (data as any[]).map((holding) => ({
-            etfName: holding.etf_name,
-            etfCode: holding.etf_code,
-            holdingName: holding.holding_name,
-            weight: holding.weight_pct,
-          }));
-          setHoldingsData(formatted);
-        }
-      } catch (err) {
-        console.error("데이터 불러오기 실패:", err);
-        if (viewMode === "ETF로 보기") setEtfData([]);
-        else setHoldingsData([]);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [searchQuery, selectedType, selectedTheme, viewMode, selectedTab]);
+  // 🔥 API 요청 트리거 (필터 변경 시에만 실행)
+  useEffect(() => {
+    // 초기 로드 시에는 실행하지 않음 (URL 파라미터 처리에서 실행됨)
+    if (searchQuery) {
+      executeSearch();
+    }
+  }, [selectedType, selectedTheme, viewMode, selectedTab]);
 
   // 비교하기 버튼 클릭 핸들러
   const handleCompareClick = async () => {
@@ -273,7 +370,7 @@ export default function FindPage() {
                   style={{ caretColor: "white" }}
                   placeholder={
                     showPlaceholder
-                      ? "상품명 혹은 종목명으로 원하는 ETF를 검색해보세요"
+                      ? "상품명 혹은 증권코드로 원하는 ETF를 검색해보세요"
                       : ""
                   }
                   value={searchQuery}
@@ -334,7 +431,7 @@ export default function FindPage() {
             count={
               viewMode === "ETF로 보기" ? etfData.length : holdingsData.length
             }
-            selectedTab={selectedTab}
+            selectedTab={""}
           />
 
           {isLoading ? (


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
메인 페이지에서 검색해서 find 페이지로 넘어가면, 그 검색어가 find 페이지에서의 검색창에 표시가 되며 검색이 가능해짐.
URL이 /find?query=KODEX 이런 식으로 보기 더럽게 넘어가던 것도 /find로 깔끔하게 보이되, 검색은 사용자가 입력한 검색어로 정상적으로 작동.
그러나 기존의 타자를 칠 때마다 요청을 보내고 바로바로 응답으로 ETF들이 뜨던 것과 달리, 검색어를 치고 엔터(또는 서치 아이콘)을 눌러야만 검색 결과가 뜸.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
